### PR TITLE
Support for non-standard ports and cleaner unsecure auth

### DIFF
--- a/app.js
+++ b/app.js
@@ -298,12 +298,17 @@ function processRequest(req, res, next) {
         }
     }
 
+    var baseHostInfo = apiConfig.baseURL.split(':');
+    var baseHostUrl = baseHostInfo[0],
+        baseHostPort = (baseHostInfo.length > 1) ? baseHostInfo[1] : "";
+
     var paramString = query.stringify(params),
         privateReqURL = apiConfig.protocol + '://' + apiConfig.baseURL + apiConfig.privatePath + methodURL + ((paramString.length > 0) ? '?' + paramString : ""),
         options = {
             headers: {},
             protocol: apiConfig.protocol,
-            host: apiConfig.baseURL,
+            host: baseHostUrl,
+            port: baseHostPort,
             method: httpMethod,
             path: apiConfig.publicPath + methodURL + ((paramString.length > 0) ? '?' + paramString : "")
         };


### PR DESCRIPTION
The main change here is support for port in the API host spec. e.g. "baseURL": "localhost:8087", but I also cleaned up the garbage in the URL when no GET params or auth is used.
