### PR TITLE
Fixed trailing slash URL bug and relative path issues

### DIFF
--- a/app.js
+++ b/app.js
@@ -692,6 +692,7 @@ app.post('/upload', function(req, res) {
 
 // API shortname, all lowercase
 app.get('/:api([^\.]+)', function(req, res) {
+    req.params.api=req.params.api.replace(/\/$/,'');
     res.render('api');
 });
 


### PR DESCRIPTION
These changes correct an issue where if an API is selected using a URL with a trailing slash, the target API JSON file can not be found. The fix is to strip off any trailing slash when such a route is used.

These changes also correct problematic relative paths described in issue #25 preventing use of standard System V style init scripts to start and stop iodocs.
