### PR TITLE
wait for the app to actually listen before calling address()

### DIFF
--- a/app.js
+++ b/app.js
@@ -699,6 +699,8 @@ app.get('/:api([^\.]+)', function(req, res) {
 
 if (!module.parent) {
     var port = process.env.PORT || config.port;
-    app.listen(port);
-    console.log("Express server listening on port %d", app.address().port);
+    var l = app.listen(port);
+    l.on('listening', function(err) {
+        console.log("Express server listening on port %d", app.address().port);
+    });
 }


### PR DESCRIPTION
I saw an error when the app was actually starting okay, because it wasn't able to give the output that the server was actually listening.  So I modified app.js as per the docs: http://nodejs.org/api/net.html#net_server_address
