### PR TITLE
Default custom headers

### DIFF
--- a/app.js
+++ b/app.js
@@ -310,7 +310,7 @@ function processRequest(req, res, next) {
     var paramString = query.stringify(params),
         privateReqURL = apiConfig.protocol + '://' + apiConfig.baseURL + apiConfig.privatePath + methodURL + ((paramString.length > 0) ? '?' + paramString : ""),
         options = {
-            headers: {},
+            headers: apiConfig.headers,
             protocol: apiConfig.protocol + ':',
             host: baseHostUrl,
             port: baseHostPort,

--- a/public/data/apiconfig.json
+++ b/public/data/apiconfig.json
@@ -4,6 +4,7 @@
         "protocol": "http",
         "baseURL": "api.klout.com",
         "publicPath": "/1",
+        "headers" : {},
         "auth": "key",
         "keyParam": "key"
     },


### PR DESCRIPTION
in apiconfig.json, you can add "headers" : {} to a config entry to use
default headers. Format is:

"header" : { "key1":"value1", "key2":"value2", ...  }
