### PR TITLE
encode URI params.

### DIFF
--- a/app.js
+++ b/app.js
@@ -310,7 +310,7 @@ function processRequest(req, res, next) {
 
                 // If the param is actually a part of the URL, put it in the URL and remove the param
                 if (!!regx.test(methodURL)) {
-                    methodURL = methodURL.replace(regx, params[param]);
+                    methodURL = methodURL.replace(regx, encodeURIComponent(params[param]));
                     delete params[param]
                 }
             } else {


### PR DESCRIPTION
This fixes the error of an malformed URL when a :param has empty spaces.

For example, having /api/:param/ with param="a b" will generate the request
"GET /api/a b  HTTP/1.1" and the target application will read as url the value
"/api/a".
