### PR TITLE
Invalid redirect_uri in token request

### DIFF
--- a/app.js
+++ b/app.js
@@ -235,7 +235,7 @@ function oauth2(req, res, next){
 
             db.set(key + ':apiKey', apiKey, redis.print);
             db.set(key + ':apiSecret', apiSecret, redis.print);
-            db.set(key + ':baseURL', req.headers.referer, redis.print);
+            db.set(key + ':baseURL', callbackURL, redis.print);
 
             // Set expiration to same as session
             db.expire(key + ':apiKey', 1209600000);


### PR DESCRIPTION
When requesting the Access token from the token URL via the authorization-code flow, the initial redirect_uri is stored in redis. The specified redirect_uri when making the token call should be the same as the intially set redirect (/oauth2Success/). A provider doing a check on the redirect_uri will reject token request
