### PR TITLE
Implemented api search feature.

### DIFF
--- a/app.js
+++ b/app.js
@@ -913,6 +913,7 @@ function processRequest(req, res, next) {
     }
 }
 
+var cachedApiInfo = [];
 
 function checkPathForAPI(req, res, next) {
     if (!req.params) req.params = {};
@@ -929,7 +930,6 @@ function checkPathForAPI(req, res, next) {
     } else {
         next();
     }
-
 }
 
 // Replaces deprecated app.dynamicHelpers that were dropped in Express 3.x
@@ -938,7 +938,8 @@ function dynamicHelpers(req, res, next) {
     if (req.params.api) {
         res.locals.apiInfo = apisConfig[req.params.api];
         res.locals.apiName = req.params.api;
-        res.locals.apiDefinition = require(__dirname + '/public/data/' + req.params.api + '.json');
+        cachedApiInfo = require(__dirname + '/public/data/' + req.params.api + '.json');
+        res.locals.apiDefinition = cachedApiInfo;
         // If the cookie says we're authed for this particular API, set the session to authed as well
         if (req.session[req.params.api] && req.session[req.params.api]['authed']) {
             req.session['authed'] = true;
@@ -951,6 +952,88 @@ function dynamicHelpers(req, res, next) {
     next();
 }
 
+// Search function.
+// Expects processed API json data and a search term.
+// There should be no 'external' link objects present.
+function search(jsonData, searchTerm) {
+    // From: http://simonwillison.net/2006/Jan/20/escape/#p-6
+    var regexFriendly = function(text) {
+        return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
+    };
+
+    // If ' OR ' is present in the search string, the search term will be split on ' OR ',
+    // and the first two parts will be used. These two parts will have spaces 
+    // stripped from them and then the regex term will present results that contain
+    // matches that have either term.
+    //
+    // If ' OR ' is not present, the given term will be searched for, spaces will not be 
+    // removed from the given term in this case.
+    var regex;
+    if (/\s+OR\s+/.test(searchTerm)) {
+        var terms = searchTerm.split(/\s+OR\s+/);
+        terms[0] = regexFriendly(terms[0].replace(/\s+/, ''));
+        terms[1] = regexFriendly(terms[1].replace(/\s+/, ''));
+        regex = new RegExp("("+terms[0]+"|"+terms[1]+")", "i");
+    }
+    else {
+        var terms = searchTerm.split(/\s+/);
+        var regexString = "";
+        for (var t = 0; t < terms.length; t++) {
+            regexString += "(?=.*" + regexFriendly(terms[t]) + ")";
+        }
+        regex = new RegExp(regexString, "i");
+    }
+
+    // Get a list of all methods from the data.
+    var searchMatches = [];
+
+    // Iterate through endpoints
+    for (var i = 0; i < jsonData.endpoints.length; i++) {
+        var object = jsonData.endpoints[i];
+
+        // Iterate through methods
+        for (var j = 0; j < object.methods.length; j++) {
+            if ( filterSearchObject(object.methods[j], regex) ) {
+                searchMatches.push({"label":object.methods[j]['MethodName'], "category": object.name, "type":object.methods[j]['HTTPMethod']});
+            }
+        }
+    }
+
+    return searchMatches;
+}
+
+// Method searching function
+// Recursively check properties of a method object for a match to the given search term.
+function filterSearchObject(randomThing, regex) {
+    var what = Object.prototype.toString;
+    if (what.call(randomThing) === '[object Array]') {
+        for (var i = 0; i < randomThing.length; i++) {
+            if (filterSearchObject(randomThing[i], regex)) {
+                return true;
+            }
+        }
+    }
+    else if (what.call(randomThing) === '[object Object]') {
+        for (var methodProperty in randomThing) {
+            if (randomThing.hasOwnProperty(methodProperty)) {
+                if (filterSearchObject(randomThing[methodProperty], regex)) {
+                    return true;
+                }
+            }
+        }
+    }
+    else if (what.call(randomThing) === '[object String]' || what.call(randomThing) === '[object Number]' ) {
+        if ( regex.test(randomThing)) {
+            return true;
+        }
+    }
+    else {
+        return false;
+    }
+
+    return false;
+}
+
 //
 // Routes
 //
@@ -958,6 +1041,20 @@ app.get('/', function(req, res) {
     res.render('listAPIs', {
         title: config.title
     });
+});
+
+//
+// Search function
+//
+// Note: If a change is made to app.js, the node process restarted, and the search 
+// function  is used immediately without restart, there will be an error coming from the 
+// search() function regarding the use of '.length'. Refresh the page, and the error 
+// will go away. A page refresh is necessary to create a cached version of the api 
+// which this route uses.
+//  Not sure what the fix for this is.
+app.get('/search', function(req, res) {
+    var searchTerm = decodeURIComponent(req.query.term);
+    res.send( search(cachedApiInfo, searchTerm) );
 });
 
 // Process the API request

--- a/public/javascripts/search.js
+++ b/public/javascripts/search.js
@@ -1,0 +1,180 @@
+(function () {
+    var searchResults;
+    var maxItems = 20;
+    $.widget( "custom.catcomplete", $.ui.autocomplete, {
+        _renderMenu: function (ul, items) {
+            searchResults = items;
+            var that = this,
+                currentCategory = "";
+
+            // Setting up an object with the count of method matches for each
+            // endpoint.
+            var matchedMethodCount = {};
+            for (var i = 0; i < items.length; i++) {
+                if (items[i].category !== currentCategory) {
+                    currentCategory = items[i].category;
+                    matchedMethodCount[currentCategory] = 0;
+                }
+                if (items[i].category === currentCategory) {
+                    matchedMethodCount[currentCategory]++;
+                }
+            }
+            currentCategory = "";
+
+            $.each( items, function (index, item) {
+                // Determining the count of methods matched for an endpoint here
+                // is probably poor for performance. Worry about it later.
+                if ( item.category != currentCategory ) {
+                    var uiItem = $( "<li>" )
+                        .addClass('ui-autocomplete-category')
+                        .text(item.category + " | Methods matched: " + matchedMethodCount[item.category] ) 
+                        // Opens and closes a given endpoint when it is clicked on
+                        .click( function (event) {
+                            $(this).nextUntil('.ui-autocomplete-category').slideToggle();
+                        })
+                        // Change the cursor and underline the endpoint text when an endpoint
+                        // is hovered over. This should provide an indication to the user to
+                        // click on given endpoint.
+                        .hover(
+                            // hoverOn
+                            function () {
+                                $(this).css('cursor', 'pointer');
+                                $(this).css('text-decoration', 'underline');
+                            },
+                            // hoverOut
+                            function () {
+                                $(this).css('text-decoration', 'none');
+                            }
+                        );
+                    ul.append(uiItem);
+                    currentCategory = item.category;
+                }
+                that._renderItem( ul, item, items.length );
+            });
+        },
+        // _renderItem is the jQuery UI function that sets up the methods for display,
+        // I couldn't find much in way of documentation for this, but it looks like 
+        // this should be function should be overriden for customization.
+        _renderItem: function (ul, item, count) {
+            var that = this;
+            // Create the anchor link for a method, same as is done in api.jade
+            var link = "#"+(item.category + '-' + item.type + '-' + item.label).replace(/\s/g, '-');
+            var processedMethod = $( "<li>" )
+                    .append( $( "<a href=" + link +">" ).text( item.label ))
+                    .addClass(item.type.toLowerCase())  // Adds the background color 
+                    .click( function (event) {          // What to do when a method is clicked on
+                        window.location.hash=link;
+                        var methodName = $(this).text();
+                        // iterate through all methods looking for equivalent method text
+                        $("div.title > span.name").each(function () {
+                            // if a method matches, find the endpoint it belongs to
+                            // and then open the endpoint. Next, click on the
+                            // method itself.
+                            if ($(this).text() === methodName) {
+                                var foundMethod = $(this).parent();
+                                endpointText = $(this).closest("ul.methods").siblings("h3.title").children("span.name");
+                                endpointText.click();
+                                foundMethod.click();
+                            }
+                        });
+                        // Close the search results box after a method has been clicked on.
+                        that.close(event);
+                        event.preventDefault();
+                    })
+                    .appendTo( ul );
+            if (count > maxItems) {
+                return processedMethod.css('display', 'none');
+            }
+            else {
+                return processedMethod;
+            }
+        }
+    });
+
+    $( "#search1" ).catcomplete({
+        source: "search",
+        minLength: 2,
+    });
+
+
+// Submitting the search term:
+// Check each endpoint to see if it exists in the search results.
+// If it does not, hide the endpoint.
+// If it does exist, then hide the methods inside the endpoint that do not
+// appear in the searchResults.
+    $('#searchForm').submit(function () {
+        var searchTerm = $('#search1').val();
+        if (searchTerm) {
+            $.get("/search", {term: searchTerm}, function (searchButtonResults) {
+                clearSearch();
+                if ( searchButtonResults.length > 0 ) {
+                    $("#search1").catcomplete("close");
+                    $('li.endpoint > h3.title span.name').each(function () {
+                        var endpointName = $(this); // span.name
+                        var endpointElement = endpointName.parent().parent(); // li.endpoint
+
+                        if( !matching(endpointName.text(), searchButtonResults) ) {
+                            endpointElement.addClass('hide-this');
+                        }
+                        else {
+                            // endpoint name matched
+                            // Deal with hiding methods that did not match. 
+                            endpointName.parent().siblings('ul.methods').children('li.method').each(function () {
+                                var method = $(this);
+                                if ( !matching(method.find('div.title span.name').text(), searchButtonResults) ) {
+                                    method.addClass('hide-this');
+                                }
+                            });
+
+                            $('ul.methods', endpointElement).slideToggle();
+                            endpointElement.toggleClass('expanded');
+                            endpointName.parent().show();
+                            endpointName.show();
+                        }
+
+                    });
+                }
+            });
+        }
+        else {
+            clearSearch();
+        }
+        return false;
+    });
+
+    $('#clear-search').click(function () {
+        clearSearch();
+        $('input#search1').val('');
+        $("form.hidden:visible").slideUp();
+    });
+
+    function matching(text, searchResults) {
+        for (var k = 0; k < searchResults.length; k++) {
+            for ( var prop in searchResults[k] ) {
+                if (searchResults[k][prop] == text) {
+                    // Match found
+                    return true;
+                }
+            }
+        }
+        // No matches found.
+        return false;
+    }
+
+    function clearSearch() {
+        $('li.method.hide-this').removeClass('hide-this');
+        // Close open endpoints
+        var endpoints = $('ul.methods'),
+            endpointsLength = endpoints.length;
+
+        for (var x = 0; x < endpointsLength; x++) {
+            var methodsList = $(endpoints[x]);
+            methodsList.slideUp();
+            methodsList.parent().toggleClass('expanded', false)
+        }
+        $('li.endpoint.hide-this').removeClass('hide-this');
+    }
+
+})();
+
+

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -835,3 +835,17 @@ dd {
     page-break-after: avoid;
   }
 }
+
+/* Type-ahead search css */
+.ui-autocomplete-category {
+    font-weight: bold;
+    padding: .2em .4em;
+    margin: .8em 0 .2em;
+    line-height: 1.5;
+}
+
+/* Use to hide endpoints and methods that do not match for a given search */
+.hide-this {
+    display: none;
+}
+

--- a/views/api.jade
+++ b/views/api.jade
@@ -54,6 +54,13 @@ block content
                       document.getElementById('oauthAuthenticated').style.display = 'block';
 
 
+  br
+  div
+      form#searchForm
+          label(for='search1') Search&nbsp;
+          input(id='search1')
+      a#clear-search(href='#') Clear search
+
   div(id='controls')
       ul
           li

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -8,7 +8,8 @@ html
         title=title
         link(rel='stylesheet', href='/stylesheets/prettify.css')
         link(rel='stylesheet', href='/stylesheets/style.css')
-
+        link(rel='stylesheet', href='https://ajax.googleapis.com/ajax/libs/jqueryui/1.9.2/themes/base/jquery.ui.all.css')
+ 
     body
         block content
         div(id='io-footer')
@@ -16,9 +17,11 @@ html
               a(href='http://mashery.com/io') Mashery, Inc.
            div(class='f-right') Powered by
               a(href='https://github.com/mashery/iodocs') I/O Docs
-        script(src='https://ajax.googleapis.com/ajax/libs/jquery/1.6/jquery.min.js')
+        script(src='https://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js')
+        script(src='https://ajax.googleapis.com/ajax/libs/jqueryui/1.9.2/jquery-ui.min.js')
         script(src='/javascripts/json2.js')
         script(src='/javascripts/prettify.js')
         script(src='/javascripts/utilities.js')
         script(src='/javascripts/livedocs.js')
         script(src='/javascripts/docs.js')
+        script(src='/javascripts/search.js')


### PR DESCRIPTION
Type-ahead feature requires at least 2 characters before results are
returned. When a given search term is submitted, all endpoints and
methods that are not part of the result set are hidden. Clearing the
search will return the page to its normal state.

Implementation details:
- If ' OR ' is present in the search string, the search term will be split
  on ' OR ', and the first two parts will be used. These two parts will have spaces
  stripped from them and then the regex term will present results that
  contain matches that have either term. Ex - search term: 'google OR twitter
  instagram' would search for any method that contains 'google' or 'twitter', but
  not 'twitter instagram' or 'instagram'.
- If ' OR ' is not present, the given term will be searched for, spaces will
  not be removed from the given term in this case.
- Space between words are considered as an implicit AND which helps
  narrow down search results. Order for the words/terms does not matter as
  long they all appear in a particular field. (Name, type, description,
  synopsis, etc.)
- Search results are limited. When more than 20 methods are matched, only
  the endpoints are shown. The endpoints can be clicked on to show the
  matched methods.
- When type-ahead result methods are clicked on, their respective full
  versions are expanded.
- Methods in search results have a background color depending on their
  HTTPMethod type, making them more visually distinct.
- Clear search results after pressing enter with an empty search field.
