### PR TITLE
Allow config.json location to be configured by argument to app.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ npm start (*nix, Mac OSX)
 npm run-script startwin (Windows)
 ```
 
+**Start I/O Docs with a custom config file**:
+
+```
+./node_modules/.bin/supervisor -e 'js|json' -- app --config-file ../config.json (*nix, Mac OSX)
+supervisor -e 'js' -- app --config-file ../config.json (Windows)
+```
+
+Ideally, the `--config-file` arg would be possible to use with `npm start`, but until
+[npm issue #3494](https://github.com/isaacs/npm/issues/3494) is resolved, this is not supported.
 
 **Point your browser** to: [localhost:3000](http://localhost:3000)
 

--- a/app.js
+++ b/app.js
@@ -38,11 +38,26 @@ var express     = require('express'),
     redis       = require('redis'),
     RedisStore  = require('connect-redis')(express);
 
+// Parse arguments
+var optimist = require('optimist')
+        .usage('Usage: $0 --config-file [file]')
+        .alias('c', 'config-file')
+        .alias('h', 'help')
+        .describe('c', 'Specify the config file location')
+        .default('c', './config.json');
+var argv = optimist.argv;
+
+if (argv.help) {
+    optimist.showHelp();
+    process.exit(0);
+}
+
 // Configuration
+var configFilePath = path.resolve(argv['config-file']);
 try {
-    var config = require('./config.json');
+    var config = require(configFilePath);
 } catch(e) {
-    console.error("File config.json not found or is invalid.  Try: `cp config.json.sample config.json`");
+    console.error("File " + configFilePath + " not found or is invalid.  Try: `cp config.json.sample config.json`");
     process.exit(1);
 }
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "oauth": "0.9.10",
     "redis": "0.8.3",
     "querystring": "0.1.0",
-    "supervisor": ">= 0.5.x"
+    "supervisor": ">= 0.5.x",
+    "optimist": ">= 0.6.0"
   },
   "devDependencies": {},
   "main": "index",


### PR DESCRIPTION
Hi,

Following on from #137, this change allows the location (and name) of config.json to be configured via a command line argument to app.js. This allows I/O Docs to be run without any modifications within the repository.

The downside is that `npm start` can't be run with arguments (they don't get passed through to the specified script), until [issue 3494 in npm](https://github.com/isaacs/npm/issues/3494) is resolved. Instead, supervisor (or node) has to be run manually.

I know that's not ideal, but I think this is a big enough win to justify the pain (until the npm issue is resolved).

Thanks,
Rowan
