### PR TITLE
Add initial simple integration test

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,12 @@
     "querystring": "0.1.0",
     "supervisor": ">= 0.5.x"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "mocha": "~1.15.1",
+    "should": "~2.1.1",
+    "supertest": "~0.8.2",
+    "nock": "~0.25.0"
+  },
   "main": "index",
   "engines": {
     "node": ">= 0.4.0",
@@ -39,6 +44,7 @@
   },
   "scripts": {
     "start": "node_modules/.bin/supervisor -e 'js|json' app",
-    "startwin": "supervisor -e 'js' app"
+    "startwin": "supervisor -e 'js' app",
+    "test": "node_modules/.bin/mocha --ui bdd --reporter spec"
   }
 }

--- a/test/SimpleApiIntegrationSpec.js
+++ b/test/SimpleApiIntegrationSpec.js
@@ -1,0 +1,48 @@
+var nock = require('nock'),
+    should = require('should'),
+    processRequestBuilderFactory = require('./helpers/process-request-builder.js'),
+    configSpawner = require('./helpers/config-spawner.js');
+
+describe('Integrating I/O Docs with a simple unauthenticated API', function() {
+    var app;
+    var service = nock('http://localhost:3001');
+    var processRequestBuilder;
+
+    before(function() {
+        configSpawner.setUpConfig(function(config){
+            config.apiConfigDir = 'test/configs/simple';
+        });
+        app = require('../app.js');
+        processRequestBuilder = processRequestBuilderFactory('simple');
+    });
+
+    after(function() {
+        configSpawner.resetConfig();
+    });
+
+    it('relays request to GET resource by ID', function(done) {
+        var id = 1234;
+        var resource = {
+            id: 1234,
+            name: "test resource"
+        };
+        var getById = service
+            .get('//resources/'+id)
+            .reply(200, resource);
+
+        processRequestBuilder
+            .get("/resources/:id")
+            .withQueryParam('id', ''+id)
+            .makeRequest(app)
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .end(function(err, res) {
+                res.body.headers.should.eql({});
+                JSON.parse(res.body.response).should.eql(resource);
+                res.body.call.should.eql('localhost:3001//resources/1234');
+                res.body.code.should.eql(200);
+                getById.done();
+                done(err);
+            });
+    });
+});

--- a/test/configs/simple/apiconfig.json
+++ b/test/configs/simple/apiconfig.json
@@ -1,0 +1,11 @@
+{
+    "simple": {
+        "name": "Simple",
+        "protocol": "http",
+        "baseURL": "localhost:3001",
+        "publicPath": "/",
+        "headers" : {},
+        "auth": "",
+        "keyParam": "key"
+    }
+}

--- a/test/configs/simple/simple.json
+++ b/test/configs/simple/simple.json
@@ -1,0 +1,25 @@
+{
+    "endpoints":[
+        {
+            "name": "CRUD operations",
+            "methods": [
+                {
+                    "MethodName":"Get some resource by ID",
+                    "Synopsis":"Lorem ipsum dolor sit amet",
+                    "HTTPMethod":"GET",
+                    "URI":"/resources/:id",
+                    "RequiresOAuth":"N",
+                    "parameters":[
+                        {
+                            "Name":"id",
+                            "Required":"Y",
+                            "Default":"",
+                            "Type":"string",
+                            "Description":"A resource ID (e.g. 500042487)"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/test/helpers/config-spawner.js
+++ b/test/helpers/config-spawner.js
@@ -1,0 +1,36 @@
+var fs = require('fs'),
+    path = require('path');
+
+var configJsonPath = path.join(process.cwd(), 'config.json');
+var configJsonBackupPath = configJsonPath + '.bak';
+var configJsonSamplePath = configJsonPath + '.sample';
+var configWasPresentBeforeTest = false;
+
+/**
+ * Back-up any existing config.json and write a new one based on config.json.sample (modified by updateCallback).
+ *
+ * @param updateCallback {function}
+ */
+exports.setUpConfig = function(updateCallback) {
+    if (fs.existsSync(configJsonPath)) {
+        configWasPresentBeforeTest = true;
+        fs.renameSync(configJsonPath, configJsonBackupPath);
+    }
+    var config = JSON.parse(fs.readFileSync(configJsonSamplePath));
+    updateCallback(config);
+    fs.writeFileSync(configJsonPath, JSON.stringify(config, null, 4));
+};
+
+/**
+ * Removes any config.json that may exist, and replaces any back-up that may have existed previously
+ */
+exports.resetConfig = function() {
+    if (fs.existsSync(configJsonPath)) {
+        if (fs.existsSync(configJsonBackupPath)) {
+            fs.unlinkSync(configJsonPath);
+            fs.renameSync(configJsonBackupPath, configJsonPath);
+        } else if (!configWasPresentBeforeTest) {
+            fs.unlinkSync(configJsonPath);
+        }
+    }
+};

--- a/test/helpers/process-request-builder.js
+++ b/test/helpers/process-request-builder.js
@@ -1,0 +1,58 @@
+var request = require('supertest');
+
+function ServiceBuilder(apiName) {
+    var get = function(URI) {
+        return ProcessRequestBuilder(apiName, "GET", URI);
+    };
+
+    return {
+        get: get
+    };
+}
+
+function ProcessRequestBuilder(apiName, httpMethod, URI) {
+    var params = {};
+    var locations = {};
+
+    /**
+     * @param key {string}
+     * @param value {string}
+     * @returns {ProcessRequestBuilder}
+     */
+    var withQueryParam = function(key, value) {
+        params[key] = value;
+        locations[key] = 'query';
+        return this;
+    };
+
+    var makeRequest = function(app) {
+        return request(app)
+            .post('/processReq')
+            .set('Content-Type', 'application/x-www-form-urlencoded')
+            .send({
+                httpMethod: httpMethod,
+                oauth: "",
+                methodUri: URI,
+                accessToken: "",
+                params: params,
+                locations: locations,
+                apiKey: "undefined",
+                apiSecret: "undefined",
+                apiName: apiName
+            });
+    };
+
+    return {
+        withQueryParam: withQueryParam,
+        makeRequest: makeRequest
+    };
+}
+
+/**
+ *
+ * @param apiName {string}
+ * @returns {ServiceBuilder}
+ */
+module.exports = function(apiName) {
+    return ServiceBuilder(apiName);
+};


### PR DESCRIPTION
Hi,

As mentioned in PR #151, I think more tests would be useful - as that PR added some simple unit tests to get the ball rolling, this adds a simple integration test, using supertest and nock to make requests to I/O Docs and mock out a remote service, respectively.

The test does a lot of faffing about moving config.json around - if #146 gets merged, we could look at avoiding that.

Thanks,
Rowan
