### PR TITLE
Make iodocs module friendly

### DIFF
--- a/app.js
+++ b/app.js
@@ -991,12 +991,9 @@ app.get('/:api([^\.]+)', function(req, res) {
     res.render('api');
 });
 
-// Only listen on $ node app.js
 
-if (!module.parent) {
-    var port = process.env.PORT || config.port;
-    var l = app.listen(port);
-    l.on('listening', function(err) {
-        console.log("Express server listening on port %d", port);
-    });
-}
+var port = process.env.PORT || config.port;
+var l = app.listen(port);
+l.on('listening', function(err) {
+    console.log("Express server listening on port %d", port);
+});

--- a/app.js
+++ b/app.js
@@ -72,7 +72,7 @@ db.on("error", function(err) {
 // Load API Configs
 //
 
-config.apiConfigDir = path.resolve(config.apiConfigDir || 'public/data');
+config.apiConfigDir = path.resolve(path.join(__dirname, config.apiConfigDir) || path.join(__dirname,  'public/data'));
 if (!fs.existsSync(config.apiConfigDir)) {
     console.error("Could not find API config directory: " + config.apiConfigDir);
     process.exit(1);

--- a/index.js
+++ b/index.js
@@ -1,0 +1,14 @@
+/**
+ * Make iodocs more module friendly by enabling config injection
+ * */
+
+module.exports = function (config) {
+  if (!config) {
+    console.error('Please provide a configuration object!');
+    process.exit(-1);
+  }
+  fs.writeFile('config.json', JSON.stringify(config), function (err) {
+    if (err) throw err;
+    return require('./app.js');
+  });
+}

--- a/index.js
+++ b/index.js
@@ -1,13 +1,15 @@
 /**
  * Make iodocs more module friendly by enabling config injection
  * */
+var fs = require('fs'),
+  path = require('path');
 
 module.exports = function (config) {
   if (!config) {
     console.error('Please provide a configuration object!');
     process.exit(-1);
   }
-  fs.writeFile('config.json', JSON.stringify(config), function (err) {
+  fs.writeFile(path.join(__dirname, 'config.json'), JSON.stringify(config), function (err) {
     if (err) throw err;
     return require('./app.js');
   });


### PR DESCRIPTION
Make iodocs module friendly, so it can be installed as a dependency: index.js created, so a config file can be injected. 

After that, this is possible:

```
var iodocs = require('iodocs')({
    "title" : "I/O Docs - http://github.com/mashery/iodocs",
    "address": "0.0.0.0",
    "port" : 5000,
    "apiConfigDir" : "../../docs",
    "debug" : false,
    "sessionSecret" : "12345",
    "basicAuth" : {
      "username" : "",
      "password" : ""
    },
    "redis" : {
      "host" : "localhost",
      "port" : 6379,
      "password" : "",
      "database" : "0"
    }
  }
);
```
