### PR TITLE
Content-Length: 0 for GET Requests

### DIFF
--- a/app.js
+++ b/app.js
@@ -821,7 +821,7 @@ function processRequest(req, res, next) {
         if(options.headers === void 0){
             options.headers = {}
         }
-        if (!options.headers['Content-Length']) {
+        if (['POST','PUT'].indexOf(httpMethod) !== -1 && !options.headers['Content-Length']) {
             if (requestBody) {
                 options.headers['Content-Length'] = requestBody.length;
             }


### PR DESCRIPTION
Maybe this is intended behavior, but I was seeing a 'Content-Length: 0' being sent in the header for GET requests. From my interpretation of RFC 2616, 'Content-Length' should only set if there is a message body. I'm no expert in the spec, so it may in fact be fine, but I found it caused an error in a REST service I was documenting, so I checked into it a bit.
