### PR TITLE
try to remove the socket file before connecting

### DIFF
--- a/app.js
+++ b/app.js
@@ -1021,10 +1021,12 @@ if (!module.parent) {
     if (typeof config.socket != "undefined") {
         var args = [config.socket];
         console.log("Express server starting on UNIX socket %s", args[0]);
+        fs.unlink(config.socket, function () {
+          app.listen.apply(app, args);
+        });
     } else {
         var args = [process.env.PORT || config.port, config.address];
         console.log("Express server starting on %s:%d", args[1], args[0]);
+        app.listen.apply(app, args);
     }
-
-    app.listen.apply(app, args);
 }


### PR DESCRIPTION
Socket file remains after node dies.  If using node with Forever or Supervisor, this will lead to EADDRINUSE errors on subsequent startups.  This patch cleans up any previous socket before creating a new one.  This is a fix to #176.
