### PR TITLE
allow comments in config, apiconfig, and data JSON files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ node_modules/*
 config.json
 logs/*
 pids/*
+
+# Ignore project files
+.idea/*
+*.iml

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "connect-redis": "1.0.6",
     "express": "3.3.1",
     "jade": "0.32.0",
+    "node-json-minify": ">= 0.1.x",
     "oauth": "0.9.10",
     "redis": "0.8.3",
     "querystring": "0.1.0",


### PR DESCRIPTION
Currently, you cannot have any comments in any JSON file.  This change uses minify to remove any comments before using the JSON.
