### PR TITLE
Display the API request headers and body in addition to the response

### DIFF
--- a/app.js
+++ b/app.js
@@ -578,7 +578,9 @@ function processRequest(req, res, next) {
         };
 
     if (['POST','DELETE','PUT'].indexOf(httpMethod) !== -1) {
-        var requestBody = query.stringify(params);
+        var requestBody;
+        requestBody = (options.headers['Content-Type'] === 'application/json') ?
+             JSON.stringify(params) : query.stringify(params);
     }
 
     if (apiConfig.oauth) {
@@ -677,6 +679,8 @@ function processRequest(req, res, next) {
                     }
 
                     // Set Headers and Call
+                    if (options.headers) req.requestHeaders = options.headers;
+                    if (requestBody) req.requestBody = requestBody;
                     if (response) {
                         req.resultHeaders = response.headers || 'None';
                     } else {
@@ -776,6 +780,8 @@ function processRequest(req, res, next) {
 
                             next();
                         } else {
+                            if (options.headers) req.requestHeaders = options.headers;
+                            if (requestBody) req.requestBody = requestBody;
                             req.resultHeaders = response.headers;
                             req.result = JSON.parse(data);
                             next();
@@ -904,6 +910,8 @@ function processRequest(req, res, next) {
                 }
 
                 // Set Headers and Call
+                if (options.headers) req.requestHeaders = options.headers;
+                if (requestBody) req.requestBody = requestBody;
                 req.resultHeaders = response.headers;
                 req.call = url.parse(options.host + options.path);
                 req.call = url.format(req.call);
@@ -988,6 +996,8 @@ app.post('/processReq', oauth, processRequest, function(req, res) {
         call: req.call,
         code: req.res.statusCode
     };
+    if (req.requestHeaders) result.requestHeaders = req.requestHeaders;
+    if (req.requestBody) result.requestBody = req.requestBody;
     res.send(result);
 });
 

--- a/public/javascripts/docs.js
+++ b/public/javascripts/docs.js
@@ -227,6 +227,12 @@
             resultContainer.append($(document.createElement('h4')).text('Call'));
             resultContainer.append($(document.createElement('pre')).addClass('call'));
 
+            resultContainer.append($(document.createElement('h4')).text('Request Headers'));
+            resultContainer.append($(document.createElement('pre')).addClass('requestHeaders'));
+
+            resultContainer.append($(document.createElement('h4')).text('Request Body'));
+            resultContainer.append($(document.createElement('pre')).addClass('requestBody'));
+
             // Code
             resultContainer.append($(document.createElement('h4')).text('Response Code'));
             resultContainer.append($(document.createElement('pre')).addClass('code prettyprint'));
@@ -276,6 +282,26 @@
             if (response.call) {
                 $('pre.call', resultContainer)
                     .text(response.call);
+            }
+
+            if (response.requestHeaders) {
+                $('pre.requestHeaders', resultContainer)
+                    .addClass('prettyprint')
+                    .text(formatJSON(response.requestHeaders));
+            } else {
+                $('pre.requestHeaders', resultContainer).hide();
+            }
+
+            if (response.requestBody) {
+                var requestBody;
+                if (response.headers['content-type'].substr(0, 16) === 'application/json') {
+                    requestBody = formatJSON(JSON.parse(response.requestBody));
+                } else {
+                    requestBody = response.requestBody;
+                }
+                $('pre.requestBody', resultContainer).addClass('prettyprint').text(requestBody);
+            } else {
+                $('pre.requestHeaders', resultContainer).hide();
             }
 
             if (response.code) {


### PR DESCRIPTION
This adds a "Request Headers" and "Request Body" section to the request output.  An API caller can now see exactly what the request that was made looks like so that they can implement the same request on their own.
