### PR TITLE
Fix content length for non ASCII (e.g. UTF8) characters

### DIFF
--- a/app.js
+++ b/app.js
@@ -862,7 +862,7 @@ function processRequest(req, res, next) {
         }
         if (['POST','PUT'].indexOf(httpMethod) !== -1 && !options.headers['Content-Length']) {
             if (requestBody) {
-                options.headers['Content-Length'] = requestBody.length;
+                options.headers['Content-Length'] = Buffer.byteLength(requestBody);
             }
             else {
                 options.headers['Content-Length'] = 0;


### PR DESCRIPTION
The Content-Length header should indicate the length in number of bytes not in number of characters. 
Replace String.length by Buffer.byteLength(String)

"é".length is 1
Buffer.byteLength("é") is 2
