### PR TITLE
Serve apiConfigDir at /data

### DIFF
--- a/app.js
+++ b/app.js
@@ -155,7 +155,7 @@ if(config.redis) {
     app.use(dynamicHelpers);
     app.use(app.router);
     app.use(express.static(__dirname + '/public'));
-    app.user('/data', express.static(config.apiConfigDir));
+    app.use('/data', express.static(config.apiConfigDir));
 });
 
 app.configure('development', function() {


### PR DESCRIPTION
To resolve mashery/iodocs#194 this change sets up the apiConfigDir to be served from /data.
