### PR TITLE
feat: Adding support for Phusion Passenger

### DIFF
--- a/app.js
+++ b/app.js
@@ -1196,4 +1196,7 @@ if (!module.parent) {
     }
 
     app.listen.apply(app, args);
+} else if (typeof(PhusionPassenger) != 'undefined') {
+  PhusionPassenger.configure({ autoInstall: false });
+  app.listen('passenger');
 }


### PR DESCRIPTION
The current listener setup only supports direct invocation of `app.js` through `node` or `npm`. This small addition to the end of the app checks further to see if `PhusionPassenger` is defined and, if so, hooks into it.
