### PR TITLE
Support sending basic auth key via headers instead of query.

### DIFF
--- a/app.js
+++ b/app.js
@@ -940,14 +940,20 @@ function processRequest(req, res, next) {
 
         // Add API Key to params, if any.
         if (apiKey != '' && apiKey != 'undefined' && apiKey != undefined) {
-            if (options.path.indexOf('?') !== -1) {
-                options.path += '&';
+            if (apiConfig.auth.key.location === 'header') {
+                options.headers = (options.headers === void 0) ? {} : options.headers;
+                options.headers[apiConfig.auth.key.param] = apiKey;
             }
             else {
-                options.path += '?';
+                if (options.path.indexOf('?') !== -1) {
+                    options.path += '&';
+                }
+                else {
+                    options.path += '?';
+                }
+                console.log(apiConfig.auth.key.param);
+                options.path += apiConfig.auth.key.param + '=' + apiKey;
             }
-            console.log(apiConfig.auth.key.param);
-            options.path += apiConfig.auth.key.param + '=' + apiKey;
         }
 
         // Basic Auth support


### PR DESCRIPTION
Example 1 says the following about the "location" param:

> (8). "location" (optional) key value sets where the api key will go in the request. Defaults to "query".

While it "defaults" to query, there does not appear to be any other options. I have an API that sends the token via a header, so I added the option to use "header" as a location for basic key authentication.
