### PR TITLE
Update pacakage.json to depend on node-json-minify: ^0.1.3-a

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "connect-redis": "1.0.6",
     "express": "3.3.1",
     "jade": "0.32.0",
-    "node-json-minify": ">= 0.1.x",
+    "node-json-minify": "^0.1.3-a",
     "oauth": "0.9.10",
     "redis": "0.8.3",
     "querystring": "0.1.0",


### PR DESCRIPTION
node-json-minify v0.1.1 is broken. That version of the module is not correctly exporting a function. The result is app.js throws on line 69. Updating node-json-minify resolves the issue.
