### PR TITLE
Hide param header & table if no method params

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "express": "3.3.1",
     "jade": "0.32.0",
     "node-json-minify": ">= 0.1.3-a",
-    "oauth": "0.9.14",
+    "oauth": "0.9.10",
     "redis": "0.8.3",
     "querystring": "0.1.0",
     "supervisor": ">= 0.5.x",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "express": "3.3.1",
     "jade": "0.32.0",
     "node-json-minify": ">= 0.1.3-a",
-    "oauth": "0.9.10",
+    "oauth": "0.9.14",
     "redis": "0.8.3",
     "querystring": "0.1.0",
     "supervisor": ">= 0.5.x",

--- a/views/api.jade
+++ b/views/api.jade
@@ -113,13 +113,13 @@ block content
                               span.description !{method.description}
                               br
                               br
-                              .container.header
-                                .row
-                                  .col-description.header Description !{method.MethodName}
-                                  .location.header Location
-                                  .col-type.header Type
-                                  .col-parameter.header Value
-                                  .col-name.header Parameter
-                              table(id=methodKey)
+                              .container.header(style=Object.keys(method.parameters).length ? undefined : "display:none")
+                                  .row
+                                      .col-description.header Description !{method.MethodName}
+                                      .location.header Location
+                                      .col-type.header Type
+                                      .col-parameter.header Value
+                                      .col-name.header Parameter
+                              table(id=methodKey, style=Object.keys(method.parameters).length ? undefined : "display:none")
                               - if (!method['read-only'])
                                   input(type='submit', id=method.name, value='Try it!', class=methodKey)

--- a/views/api.jade
+++ b/views/api.jade
@@ -113,13 +113,15 @@ block content
                               span.description !{method.description}
                               br
                               br
-                              .container.header(style=Object.keys(method.parameters).length ? undefined : "display:none")
+                              - var noParams = ((Object.keys(method.parameters).length < 1) && !method.request)
+                              .container.header(style=noParams ? "display:none" : undefined)
                                   .row
                                       .col-description.header Description !{method.MethodName}
                                       .location.header Location
                                       .col-type.header Type
                                       .col-parameter.header Value
                                       .col-name.header Parameter
-                              table(id=methodKey, style=Object.keys(method.parameters).length ? undefined : "display:none")
+                              table(id=methodKey, style=noParams ? "display:none": undefined)
                               - if (!method['read-only'])
                                   input(type='submit', id=method.name, value='Try it!', class=methodKey)
+


### PR DESCRIPTION
When a method doesn't have any params, we hide the table header row. We also hide the `<table>` that Alpaca renders the parameters into to eliminate the extra white space.
